### PR TITLE
added proxy support

### DIFF
--- a/maven-repository-provisioner/pom.xml
+++ b/maven-repository-provisioner/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.3</version>
+      <version>4.3.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ArtifactRetriever.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ArtifactRetriever.java
@@ -70,7 +70,9 @@ public class ArtifactRetriever
     public void retrieve( List<String> artifactCoordinates, String sourceUrl, boolean includeSources,
                           boolean includeJavadoc )
     {
-        sourceRepository = new RemoteRepository.Builder( "central", "default", sourceUrl ).build();
+        RemoteRepository.Builder builder = new RemoteRepository.Builder("central", "default", sourceUrl);
+        builder.setProxy(ProxyHelper.getProxy(sourceUrl));
+        sourceRepository = builder.build();
 
         List<ArtifactResult> artifactResults = getArtifactResults( artifactCoordinates );
 

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
@@ -65,7 +65,8 @@ public class MavenRepositoryProvisioner
                 logger.info( "Source: " + config.getSourceUrl() );
                 logger.info( "Target: " + config.getTargetUrl() );
                 logger.info( "Username: " + config.getUsername() );
-                logger.info( "Password: " + config.getPassword().replaceAll( ".", "***" ) );
+                if(config.getPassword()!=null)
+                    logger.info( "Password: " + config.getPassword().replaceAll( ".", "***" ) );
                 logger.info( "IncludeSources:" + config.getIncludeSources() );
                 logger.info( "IncludeJavadoc:" + config.getIncludeJavadoc() );
                 logger.info( "Local cache directory: " + config.getCacheDirectory() );

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ProxyHelper.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ProxyHelper.java
@@ -1,0 +1,26 @@
+package com.simpligility.maven.provisioner;
+
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+
+public class ProxyHelper {
+  public static Proxy getProxy(String sourceUrl) {
+
+    String protocol="http";
+
+    Authentication auth=null;
+    Proxy proxy=null;
+    if(System.getProperty(String.format("%s.proxyUser", protocol)) != null) {
+      auth = new AuthenticationBuilder()
+          .addUsername(System.getProperty(String.format("%s.proxyUser", protocol)))
+          .addPassword(System.getProperty(String.format("%s.proxyPassword", protocol))).build();
+    }
+
+    if(System.getProperty(String.format("%s.proxyHost", protocol)) != null)
+      proxy=new Proxy(protocol, System.getProperty(String.format("%s.proxyHost", protocol)),
+                  Integer.parseInt(System.getProperty(String.format("%s.proxyPort", protocol))), auth);
+
+      return proxy;
+  }
+}


### PR DESCRIPTION
Hi,
here are two proposed changes:
- a small fix to avoid a NullPointerException in replaceAll in case the config password is null
- enable http proxy in downloading dependencies from a remote repository. Proxy is configured through the standard Java system properties:
  - http.proxyHost
  - http.proxyPort
  - http.proxyUser
  - http.proxyPassword

I needed to upgrade httpclient to version 4.3.4 (otherwise an exception is raised).
Tested with Squid on Windows (with and without authentication)