### PR TITLE
Maven Resolver instead of Eclipse Aether

### DIFF
--- a/maven-repository-provisioner/pom.xml
+++ b/maven-repository-provisioner/pom.xml
@@ -64,47 +64,47 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
       <version>${mavenVersion}</version>
     </dependency>
+<!--     <dependency> -->
+<!--       <groupId>org.codehaus.plexus</groupId> -->
+<!--       <artifactId>plexus-utils</artifactId> -->
+<!--     </dependency> -->
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-file</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-file</artifactId>
-      <version>${aetherVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-http</artifactId>
-      <version>${aetherVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
   </dependencies>
 

--- a/maven-repository-provisioner/pom.xml
+++ b/maven-repository-provisioner/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
+      <version>4.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/maven-repository-provisioner/pom.xml
+++ b/maven-repository-provisioner/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.5</version>
+      <version>3.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/AetherModule.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/AetherModule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.maven.repository.internal.MavenAetherModule;
+import org.apache.maven.repository.internal.MavenResolverModule;
 import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
@@ -35,7 +35,7 @@ class AetherModule
     @Override
     protected void configure()
     {
-        install( new MavenAetherModule() );
+        install( new MavenResolverModule() );
         // alternatively, use the Guice Multibindings extensions
         bind( RepositoryConnectorFactory.class ).annotatedWith( Names.named( "basic" ) )
             .to( BasicRepositoryConnectorFactory.class );

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ArtifactRetriever.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ArtifactRetriever.java
@@ -169,7 +169,14 @@ public class ArtifactRetriever
             catch ( NullPointerException npe )
             {
                 logger.info( "NullPointerException resolving dependencies ", npe );
-                failedRetrievals.add( npe.getMessage() );
+                if ( npe.getMessage() != null )
+                {
+                  failedRetrievals.add( npe.getMessage() );
+                }
+                else
+                {
+                  failedRetrievals.add( "NPE retrieving" + artifact );
+                }
             }
         }
 

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ArtifactRetriever.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/ArtifactRetriever.java
@@ -168,14 +168,14 @@ public class ArtifactRetriever
             }
             catch ( NullPointerException npe )
             {
-                logger.info( "NullPointerException resolving dependencies ", npe );
+                logger.info( "NullPointerException resolving dependencies for " + artifact + ":" + npe );
                 if ( npe.getMessage() != null )
                 {
-                  failedRetrievals.add( npe.getMessage() );
+                    failedRetrievals.add( npe.getMessage() );
                 }
                 else
                 {
-                  failedRetrievals.add( "NPE retrieving" + artifact );
+                    failedRetrievals.add( "NPE retrieving " + artifact );
                 }
             }
         }

--- a/maven-repository-provisioner/test.sh
+++ b/maven-repository-provisioner/test.sh
@@ -33,7 +33,7 @@ function deploy {
 
 #deploy "junit:junit:4.11"
 #deploy "org.testng:testng:jar:6.9.10"
-deploy "org.apache.commons:commons-lang3:jar:3.3.2"
+#deploy "org.apache.commons:commons-lang3:jar:3.3.2"
 #deploy "org.apache.abdera:abdera-bundle:1.1.3"
 #deploy "com.google.inject:guice:jar:no_aop:3.0"
 #deploy "org.apache.commons:commons-lang3:jar:3.3.2|junit:junit:4.11|com.squareup.assertj:assertj-android:aar:1.1.1"
@@ -57,7 +57,7 @@ deploy "org.apache.commons:commons-lang3:jar:3.3.2"
 #deploy org.drools:drools-compiler:6.5.0.Final
 #deploy org.drools:drools-compiler:bundle:6.5.0.Final
 #deploy org.kie:kie-api:bundle:6.5.0.Final
-#deploy org.kie:kie-api:6.5.0.Final
+deploy org.kie:kie-api:6.5.0.Final
 
 # testing hpi packaging, both should get a hpi file and a jar file
 #deploy org.jenkins-ci.plugins:git:hpi:3.4.0

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </issueManagement>
 
   <properties>
-    <mavenResolverVersion>1.1.0</mavenResolverVersion>
+    <mavenResolverVersion>1.1.1</mavenResolverVersion>
     <mavenVersion>3.5.2</mavenVersion>
     <java.version>1.8</java.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,8 @@
   </issueManagement>
 
   <properties>
-    <aetherVersion>1.1.0</aetherVersion>
-    <!-- Upgrade to 3.3.9 fails at runtime with NPE, need to investigate -->
-    <mavenVersion>3.1.0</mavenVersion>
+    <mavenResolverVersion>1.1.0</mavenResolverVersion>
+    <mavenVersion>3.5.0</mavenVersion>
     <java.version>1.8</java.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
   <properties>
     <mavenResolverVersion>1.1.0</mavenResolverVersion>
-    <mavenVersion>3.5.1-SNAPSHOT</mavenVersion>
+    <mavenVersion>3.5.2</mavenVersion>
     <java.version>1.8</java.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
   <properties>
     <mavenResolverVersion>1.1.0</mavenResolverVersion>
-    <mavenVersion>3.5.0</mavenVersion>
+    <mavenVersion>3.5.1-SNAPSHOT</mavenVersion>
     <java.version>1.8</java.version>
   </properties>
 


### PR DESCRIPTION
Upgrade to Maven 3.5.0 and usage of Maven Resolver.

Currently this is blocked by an NPE that is caused by VersionRangeResolver being null. The cause of the null is fixed in Maven master. See https://github.com/apache/maven/commit/66fc74d6296ea0a33f8a9712dc5ed5eb3affd529#diff-3823d220488dec8b664a667b39df7a29L119

So I will need to wait for 3.5.1 in order to release this.


