### PR TITLE
Ignore hidden files

### DIFF
--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/VisibleDirectoryFileFilter.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/VisibleDirectoryFileFilter.java
@@ -6,14 +6,14 @@ import java.io.Serializable;
 import org.apache.commons.io.filefilter.AbstractFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
 
-public class VisibleDirectoryFileFilter extends AbstractFileFilter implements Serializable 
+public class VisibleDirectoryFileFilter extends AbstractFileFilter implements Serializable
 {
   private static final long serialVersionUID = -2364729562384525732L;
-  
+
   public static final IOFileFilter DIRECTORY = new VisibleDirectoryFileFilter();
-  
+
   public static final IOFileFilter INSTANCE = DIRECTORY;
-  
+
   protected VisibleDirectoryFileFilter()
   {
   }
@@ -28,7 +28,7 @@ public class VisibleDirectoryFileFilter extends AbstractFileFilter implements Se
   public boolean accept( final File file )
   {
       boolean startsWithDot = !file.getName().isEmpty() && file.getName().startsWith( "." );
-      boolean isVisible = !file.isHidden() || !startsWithDot;
+      boolean isVisible = !file.isHidden() && !startsWithDot;
       return file.isDirectory() && isVisible;
   }
 


### PR DESCRIPTION
Consider a file as visible if it is not hidden and it does not start with a dot.

Using the utility to copy artifacts from a Nexus 2 repository on the filesystem to Nexus 3 failed because the utility treated the Nexus control directories (.index, .meta, .nexus) as visible.

This change will treat . files as hidden even when they're not on Unix, and allows the copying to progress.