### PR TITLE
Feature/Fix: Handle Snapshots (and ignore .md5 files)

### DIFF
--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/Gav.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/Gav.java
@@ -37,6 +37,11 @@ public final class Gav
         return version;
     }
 
+    public String getVersionWithoutSnapshot()
+    {
+        return version.replace( "-SNAPSHOT", "" );
+    }
+
     public String getPackaging()
     {
         return packaging;

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeployer.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeployer.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.filefilter.AndFileFilter;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.NotFileFilter;
+import org.apache.commons.io.filefilter.OrFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.commons.lang3.StringUtils;
@@ -118,7 +119,9 @@ public class MavenRepositoryDeployer
         for ( File leafDirectory : leafDirectories )
         {
             IOFileFilter fileFilter = new AndFileFilter( new WildcardFileFilter( "*.pom" ),
-                                               new NotFileFilter( new SuffixFileFilter( "sha1" ) ) );
+                                               new NotFileFilter( new OrFileFilter(
+                                                       new SuffixFileFilter( "sha1" ),
+                                                       new SuffixFileFilter( "md5" ) ) ) );
             pomFiles.addAll( FileUtils.listFiles( leafDirectory, fileFilter, null ) );
         }
         return pomFiles;
@@ -152,10 +155,13 @@ public class MavenRepositoryDeployer
             else
             {
                 // only interested in files using the artifactId-version* pattern
-                // don't bother with .sha1 files
+                // don't bother with .sha1 / .md5 files
                 IOFileFilter fileFilter =
-                    new AndFileFilter( new WildcardFileFilter( gav.getArtifactId() + "-" + gav.getVersion() + "*" ),
-                                       new NotFileFilter( new SuffixFileFilter( "sha1" ) ) );
+                    new AndFileFilter(
+                            new WildcardFileFilter( gav.getArtifactId() + "-" + gav.getVersionWithoutSnapshot() + "*" ),
+                                       new NotFileFilter( new OrFileFilter(
+                                               new SuffixFileFilter( "sha1" ),
+                                               new SuffixFileFilter( "md5" ) ) ) );
                 Collection<File> artifacts = FileUtils.listFiles( leafDirectory, fileFilter, null );
 
                 Authentication auth = new AuthenticationBuilder().addUsername( username ).addPassword( password )


### PR DESCRIPTION
There is an issue with snapshots being located under `/snapshots/<version>-SNAPSHOT/artifact`, where there can be multiple versions of the same snapshots, they do not contain `-SNAPSHOT` in their name (artifacts), better to just filter on `<version>*` without -SNAPSHOT (within the `<version>-SNAPSHOT `folder)

Note: Also noticed it didn't skip .md5 files