### PR TITLE
Add a configuration to specify a filter file for what to deploy

### DIFF
--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/Gav.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/Gav.java
@@ -4,6 +4,8 @@
  */
 package com.simpligility.maven;
 
+import java.util.Objects;
+
 public final class Gav {
     private final String groupId;
 
@@ -58,6 +60,26 @@ public final class Gav {
 
     public String getRepositoryURLPath() {
         return groupId.replace(".", "/") + "/" + artifactId + "/" + version + "/";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Gav gav = (Gav) obj;
+        return groupId.equals(gav.getGroupId())
+                && artifactId.equals(gav.getArtifactId())
+                && version.equals(gav.getVersion())
+                && packaging.equals(gav.getPackaging());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, version, packaging);
     }
 
     @Override

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/GavMatcher.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/GavMatcher.java
@@ -1,0 +1,24 @@
+package com.simpligility.maven;
+
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+public class GavMatcher implements Callable<Boolean>, Supplier<Boolean> {
+    private final Gav gav;
+    private final GavPattern pattern;
+
+    public GavMatcher(Gav gav, GavPattern pattern) {
+        this.gav = gav;
+        this.pattern = pattern;
+    }
+
+    @Override
+    public Boolean call() {
+        return pattern.matches(gav);
+    }
+
+    @Override
+    public Boolean get() {
+        return call();
+    }
+}

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/GavPattern.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/GavPattern.java
@@ -1,0 +1,27 @@
+package com.simpligility.maven;
+
+import java.util.regex.Pattern;
+
+public class GavPattern {
+    private final Pattern pattern;
+    private final boolean inverse;
+
+    public GavPattern(Pattern pattern, boolean inverse) {
+        this.inverse = inverse;
+        this.pattern = pattern;
+    }
+
+    public boolean matches(Gav gav) {
+        if (gav == null) {
+            return false;
+        }
+        String gavString =
+                gav.getGroupId() + ":" + gav.getArtifactId() + ":" + gav.getVersion() + ":" + gav.getPackaging();
+        boolean matchResult = pattern.matcher(gavString).matches();
+
+        if (inverse) {
+            return !matchResult;
+        }
+        return matchResult;
+    }
+}

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
@@ -121,6 +121,15 @@ public class Configuration {
                     "Number of threads to use for parallel deployment. Ignored if parallelDeploy is false. Defaults to 5.")
     private int deployThreads = 5;
 
+    @Parameter(
+            names = {"-df", "deployFilterFile"},
+            description = "File path to a filter file that specifies what is or isn't deployed remotely. "
+                    + "The file should contain GAV (groupId:artifactId:version:extension) patterns, one per line. "
+                    + "If a line starts with a '!', that GAV will NOT be deployed remotely. "
+                    + "By default, no filter file is specified, and everything in the local repository is deployed.",
+            arity = 1)
+    private String deployFilterFile;
+
     public void setSourceUrl(String sourceUrl) {
         this.sourceUrl = sourceUrl;
     }
@@ -175,6 +184,10 @@ public class Configuration {
 
     public void setVerifyOnly(Boolean verifyOnly) {
         this.verifyOnly = verifyOnly;
+    }
+
+    public void setDeployFilterFile(String deployFilterFile) {
+        this.deployFilterFile = deployFilterFile;
     }
 
     public void setParallelDeploy(Boolean parallelDeploy) {
@@ -259,6 +272,10 @@ public class Configuration {
 
     public Boolean getVerifyOnly() {
         return verifyOnly;
+    }
+
+    public String getDeployFilterFile() {
+        return deployFilterFile;
     }
 
     public Boolean getParallelDeploy() {

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/GavMatcherExecutor.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/GavMatcherExecutor.java
@@ -1,0 +1,35 @@
+package com.simpligility.maven.provisioner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import com.simpligility.maven.Gav;
+import com.simpligility.maven.GavMatcher;
+import com.simpligility.maven.GavPattern;
+
+public class GavMatcherExecutor implements AutoCloseable {
+    private final ExecutorService executorService;
+
+    public GavMatcherExecutor(int threadPoolSize) {
+        this.executorService = Executors.newFixedThreadPool(threadPoolSize);
+    }
+
+    public List<CompletableFuture<Boolean>> evaluateGav(Gav gav, Set<GavPattern> patterns) {
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+        for (GavPattern pattern : patterns) {
+            CompletableFuture<Boolean> future =
+                    CompletableFuture.supplyAsync(new GavMatcher(gav, pattern), executorService);
+            futures.add(future);
+        }
+        return futures;
+    }
+
+    @Override
+    public void close() throws Exception {
+        executorService.shutdown();
+    }
+}

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/GavMatcherTest.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/GavMatcherTest.java
@@ -1,0 +1,62 @@
+package com.simpligility.maven;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class GavMatcherTest {
+
+    @Test
+    public void testCall_MatchingPattern() throws ExecutionException, InterruptedException {
+        GavPattern pattern = new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), false);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        GavMatcher matcher = new GavMatcher(gav, pattern);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> result = executor.submit(matcher);
+        assertTrue(result.get());
+        executor.shutdown();
+    }
+
+    @Test
+    public void testCall_NonMatchingPattern() throws ExecutionException, InterruptedException {
+        GavPattern pattern = new GavPattern(Pattern.compile("com\\.simpligility:.*:.*:.*"), false);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        GavMatcher matcher = new GavMatcher(gav, pattern);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> result = executor.submit(matcher);
+        assertFalse(result.get());
+        executor.shutdown();
+    }
+
+    @Test
+    public void testCall_EmptyPattern() throws ExecutionException, InterruptedException {
+        GavPattern pattern = new GavPattern(Pattern.compile(""), false);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        GavMatcher matcher = new GavMatcher(gav, pattern);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> result = executor.submit(matcher);
+        assertFalse(result.get());
+        executor.shutdown();
+    }
+
+    @Test
+    public void testCall_NullGav() throws ExecutionException, InterruptedException {
+        GavPattern pattern = new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), false);
+        GavMatcher matcher = new GavMatcher(null, pattern);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> result = executor.submit(matcher);
+        assertFalse(result.get());
+        executor.shutdown();
+    }
+}

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/GavPatternTest.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/GavPatternTest.java
@@ -1,0 +1,59 @@
+package com.simpligility.maven;
+
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class GavPatternTest {
+
+    @Test
+    public void testMatches_ValidPattern() {
+        GavPattern pattern = new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), false);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        assertTrue(pattern.matches(gav));
+    }
+
+    @Test
+    public void testMatches_InvalidPattern() {
+        GavPattern pattern = new GavPattern(Pattern.compile("com\\.simpligility:.*:.*:.*"), false);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        assertFalse(pattern.matches(gav));
+    }
+
+    @Test
+    public void testMatches_EmptyPattern() {
+        GavPattern pattern = new GavPattern(Pattern.compile(""), false);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        assertFalse(pattern.matches(gav));
+    }
+
+    @Test
+    public void testMatches_NullGav() {
+        GavPattern pattern = new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), false);
+        assertFalse(pattern.matches(null));
+    }
+
+    @Test
+    public void testMatches_ValidPattern_Inverse() {
+        GavPattern pattern = new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), true);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        assertFalse(pattern.matches(gav));
+    }
+
+    @Test
+    public void testMatches_InvalidPattern_Inverse() {
+        GavPattern pattern = new GavPattern(Pattern.compile("com\\.simpligility:.*:.*:.*"), true);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        assertTrue(pattern.matches(gav));
+    }
+
+    @Test
+    public void testMatches_EmptyPattern_Inverse() {
+        GavPattern pattern = new GavPattern(Pattern.compile(""), true);
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+        assertTrue(pattern.matches(gav));
+    }
+}

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/GavTest.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/GavTest.java
@@ -1,0 +1,30 @@
+package com.simpligility.maven;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class GavTest {
+
+    @Test
+    public void testEquals() {
+        Gav gav1 = new Gav("groupId", "artifactId", "version", "jar");
+        Gav gav2 = new Gav("groupId", "artifactId", "version", "jar");
+        Gav gav3 = new Gav("groupId", "artifactId", "differentVersion", "jar");
+
+        assertTrue(gav1.equals(gav2));
+        assertFalse(gav1.equals(gav3));
+        assertFalse(gav1.equals(null));
+        assertFalse(gav1.equals(new Object()));
+    }
+
+    @Test
+    public void testHashCode() {
+        Gav gav1 = new Gav("groupId", "artifactId", "version", "jar");
+        Gav gav2 = new Gav("groupId", "artifactId", "version", "jar");
+        Gav gav3 = new Gav("groupId", "artifactId", "differentVersion", "jar");
+
+        assertEquals(gav1.hashCode(), gav2.hashCode());
+        assertNotEquals(gav1.hashCode(), gav3.hashCode());
+    }
+}

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/GavMatcherExecutorTest.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/GavMatcherExecutorTest.java
@@ -1,0 +1,128 @@
+package com.simpligility.maven.provisioner;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.simpligility.maven.Gav;
+import com.simpligility.maven.GavPattern;
+import org.junit.Test;
+
+public class GavMatcherExecutorTest {
+
+    @Test
+    public void testEvaluateGav_MatchingPattern() throws ExecutionException, InterruptedException {
+        Set<GavPattern> patterns = new HashSet<>();
+        patterns.add(new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), false));
+
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+
+        try (GavMatcherExecutor executor = new GavMatcherExecutor(4)) {
+            List<CompletableFuture<Boolean>> results = executor.evaluateGav(gav, patterns);
+            boolean matchFound = false;
+            for (CompletableFuture<Boolean> result : results) {
+                if (result.get()) {
+                    matchFound = true;
+                    break;
+                }
+            }
+            assertTrue(matchFound);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testEvaluateGav_NonMatchingPattern() throws ExecutionException, InterruptedException {
+        Set<GavPattern> patterns = new HashSet<>();
+        patterns.add(new GavPattern(Pattern.compile("com\\.simpligility:.*:.*:.*"), false));
+
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+
+        try (GavMatcherExecutor executor = new GavMatcherExecutor(4)) {
+            List<CompletableFuture<Boolean>> results = executor.evaluateGav(gav, patterns);
+            boolean matchFound = false;
+            for (CompletableFuture<Boolean> result : results) {
+                if (result.get()) {
+                    matchFound = true;
+                    break;
+                }
+            }
+            assertFalse(matchFound);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testEvaluateGav_EmptyPatternSet() throws ExecutionException, InterruptedException {
+        Set<GavPattern> patterns = new HashSet<>();
+
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+
+        try (GavMatcherExecutor executor = new GavMatcherExecutor(4)) {
+            List<CompletableFuture<Boolean>> results = executor.evaluateGav(gav, patterns);
+            boolean matchFound = false;
+            for (CompletableFuture<Boolean> result : results) {
+                if (result.get()) {
+                    matchFound = true;
+                    break;
+                }
+            }
+            assertFalse(matchFound);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testEvaluateGav_NullGav() throws ExecutionException, InterruptedException {
+        Set<GavPattern> patterns = new HashSet<>();
+        patterns.add(new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), false));
+
+        try (GavMatcherExecutor executor = new GavMatcherExecutor(4)) {
+            List<CompletableFuture<Boolean>> results = executor.evaluateGav(null, patterns);
+            boolean matchFound = false;
+            for (CompletableFuture<Boolean> result : results) {
+                if (result.get()) {
+                    matchFound = true;
+                    break;
+                }
+            }
+            assertFalse(matchFound);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testEvaluateGav_MultiplePatternsWithDifferentResults() throws ExecutionException, InterruptedException {
+        Set<GavPattern> patterns = new HashSet<>();
+        patterns.add(
+                new GavPattern(Pattern.compile("org\\.apache\\.maven\\.resolver:.*:.*:.*"), false)); // Should match
+        patterns.add(new GavPattern(Pattern.compile("com\\.simpligility:.*:.*:.*"), false)); // Should not match
+        patterns.add(new GavPattern(Pattern.compile("org\\.apache\\.commons:.*:.*:.*"), false)); // Should not match
+
+        Gav gav = new Gav("org.apache.maven.resolver", "artifactId", "version", "jar");
+
+        try (GavMatcherExecutor executor = new GavMatcherExecutor(4)) {
+            List<CompletableFuture<Boolean>> results = executor.evaluateGav(gav, patterns);
+            boolean matchFound = false;
+            for (CompletableFuture<Boolean> result : results) {
+                if (result.get()) {
+                    matchFound = true;
+                    break;
+                }
+            }
+            assertTrue(matchFound);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/MavenRepositoryDeployerTest.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/MavenRepositoryDeployerTest.java
@@ -1,0 +1,81 @@
+package com.simpligility.maven.provisioner;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+import com.simpligility.maven.Gav;
+import com.simpligility.maven.GavPattern;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MavenRepositoryDeployerTest {
+
+    private MavenRepositoryDeployer deployer;
+    private Configuration config;
+
+    @Before
+    public void setUp() {
+        config = new Configuration();
+        deployer = new MavenRepositoryDeployer(config);
+    }
+
+    @Test
+    public void testLoadGavsFromFilterFile_ValidFile() throws IOException {
+        File tempFile = createTempFile("org.apache.maven.resolver:maven-resolver:1.0.0:*\n");
+        config.setDeployFilterFile(tempFile.getAbsolutePath());
+        Set<GavPattern> gavPatterns = deployer.loadGavPatternsFromFilterFile(tempFile.getAbsolutePath());
+        assertEquals(1, gavPatterns.size());
+        assertTrue(gavPatterns
+                .iterator()
+                .next()
+                .matches(new Gav("org.apache.maven.resolver", "maven-resolver", "1.0.0", "jar")));
+        tempFile.delete();
+    }
+
+    @Test
+    public void testLoadGavsFromFilterFile_EmptyFile() throws IOException {
+        File tempFile = createTempFile("");
+        config.setDeployFilterFile(tempFile.getAbsolutePath());
+        Set<GavPattern> gavPatterns = deployer.loadGavPatternsFromFilterFile(tempFile.getAbsolutePath());
+        assertTrue(gavPatterns.isEmpty());
+        tempFile.delete();
+    }
+
+    @Test
+    public void testLoadGavsFromFilterFile_InvalidFormat() throws IOException {
+        File tempFile = createTempFile("invalid:format\n");
+        config.setDeployFilterFile(tempFile.getAbsolutePath());
+        Set<GavPattern> gavPatterns = deployer.loadGavPatternsFromFilterFile(tempFile.getAbsolutePath());
+        assertTrue(gavPatterns.isEmpty());
+        tempFile.delete();
+    }
+
+    @Test
+    public void testLoadGavsFromFilterFile_MixedValidAndInvalid() throws IOException {
+        File tempFile = createTempFile("org.apache.maven:apache-maven:3.9.9:*\ninvalid:format\n");
+        config.setDeployFilterFile(tempFile.getAbsolutePath());
+        Set<GavPattern> gavPatterns = deployer.loadGavPatternsFromFilterFile(tempFile.getAbsolutePath());
+        assertEquals(1, gavPatterns.size());
+        assertTrue(gavPatterns.iterator().next().matches(new Gav("org.apache.maven", "apache-maven", "3.9.9", "jar")));
+        tempFile.delete();
+    }
+
+    @Test
+    public void testLoadGavsFromFilterFile_NonExistentFile() {
+        Set<GavPattern> gavPatterns = deployer.loadGavPatternsFromFilterFile("nonexistentfile.txt");
+        assertTrue(gavPatterns.isEmpty());
+    }
+
+    private File createTempFile(String content) throws IOException {
+        File tempFile = File.createTempFile("gavFilter", ".txt");
+        config.setDeployFilterFile(tempFile.getAbsolutePath());
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write(content);
+        }
+        return tempFile;
+    }
+}


### PR DESCRIPTION
Adds a -df -deployFilterfile configuration that is a file path to load for telling the MavenRepositoryDeployer which GAVs to deploy. This file contains a groupId:artifactId:version:ext per line, and is loaded into memory as a Set<Gav>. It implements the Object.equals method on Gav so that we can compare GAVs in order to know if it is in the filter file or not. If the filter file is not specified, or doesnt exist, we do not filter at all.

Fixes: https://github.com/simpligility/maven-repository-tools/issues/81